### PR TITLE
Pr ahrs subscription and hardpoint fix

### DIFF
--- a/include/application/can_driver.h
+++ b/include/application/can_driver.h
@@ -42,10 +42,10 @@ inline CanProtocol canDriverGetProtocol(uint8_t can_driver_idx) {
     if (canDriverReceive(&rx_frame, can_driver_idx) == 0) {
         const uint8_t tail_byte = rx_frame.data[rx_frame.data_len - 1];
         if (IS_START_OF_TRANSFER(tail_byte) && IS_END_OF_TRANSFER(tail_byte)) {
-            return TOGGLE_BIT(tail_byte);
+            return TOGGLE_BIT(tail_byte) ? CAN_PROTOCOL_CYPHAL: CAN_PROTOCOL_DRONECAN;
         }
     }
-    return -1;
+    return CAN_PROTOCOL_UNKNOWN;
 }
 
 uint64_t canDriverGetRxOverflowCount();

--- a/include/serialization/publisher.hpp
+++ b/include/serialization/publisher.hpp
@@ -14,6 +14,7 @@
 #include "uavcan/equipment/actuator/Status.h"
 #include "uavcan/equipment/ahrs/MagneticFieldStrength2.h"
 #include "uavcan/equipment/ahrs/RawImu.h"
+#include "uavcan/equipment/ahrs/Solution.h"
 #include "uavcan/equipment/air_data/IndicatedAirspeed.h"
 #include "uavcan/equipment/air_data/RawAirData.h"
 #include "uavcan/equipment/air_data/StaticPressure.h"
@@ -41,6 +42,7 @@ struct DronecanPublisherTraits<MessageType> { \
 DEFINE_PUBLISHER_TRAITS(ActuatorStatus_t,   dronecan_equipment_actuator_status_publish)
 DEFINE_PUBLISHER_TRAITS(MagneticFieldStrength2, dronecan_equipment_ahrs_magnetic_field_2_publish)
 DEFINE_PUBLISHER_TRAITS(AhrsRawImu,         dronecan_equipment_ahrs_raw_imu_publish)
+DEFINE_PUBLISHER_TRAITS(AhrsSolution_t,     dronecan_equipment_ahrs_solution_publish)
 DEFINE_PUBLISHER_TRAITS(IndicatedAirspeed,  dronecan_equipment_air_data_indicated_airspeed_publish)
 DEFINE_PUBLISHER_TRAITS(RawAirData_t,       dronecan_equipment_air_data_raw_air_data_publish)
 DEFINE_PUBLISHER_TRAITS(StaticPressure,     dronecan_equipment_air_data_static_pressure_publish)

--- a/include/serialization/subscriber.hpp
+++ b/include/serialization/subscriber.hpp
@@ -17,6 +17,7 @@
 #include "uavcan/equipment/indication/LightsCommand.h"
 #include "uavcan/equipment/power/CircuitStatus.h"
 #include "uavcan/equipment/safety/ArmingStatus.h"
+#include "uavcan/equipment/ahrs/Solution.h"
 #include "uavcan/equipment/hardpoint/Command.h"
 
 template <typename MessageType>
@@ -51,7 +52,9 @@ DEFINE_SUBSCRIBER_TRAITS(SafetyArmingStatus,
 DEFINE_SUBSCRIBER_TRAITS(HardpointCommand,
                          uavcanSubscribeHardpointCommand,
                          dronecan_equipment_hardpoint_command_deserialize)
-
+DEFINE_SUBSCRIBER_TRAITS(AhrsSolution_t,
+                         uavcanSubscribeAhrsSolution,
+                         dronecan_equipment_ahrs_solution_deserialize)
 
 template <typename MessageType>
 class DronecanSubscriber {

--- a/include/serialization/uavcan/equipment/ahrs/Solution.h
+++ b/include/serialization/uavcan/equipment/ahrs/Solution.h
@@ -15,6 +15,7 @@
 #define UAVCAN_EQUIPMENT_AHRS_SOLUTION_SIGNATURE                    0x72a63a3c6f41fa9b
 #define UAVCAN_EQUIPMENT_AHRS_SOLUTION_MESSAGE_SIZE                 29  // 668 bits
 #define UAVCAN_EQUIPMENT_AHRS_SOLUTION                              UAVCAN_EXPAND(UAVCAN_EQUIPMENT_AHRS_SOLUTION)
+#define UAVCAN_EQUIPMENT_AHRS_SOLUTION UAVCAN_EXPAND(UAVCAN_EQUIPMENT_AHRS_SOLUTION)
 
 /**
  * @brief uavcan.equipment.ahrs.Solution
@@ -40,6 +41,94 @@ extern "C" {
 #endif
 
 
+static inline int8_t dronecan_equipment_ahrs_solution_deserialize(
+    const CanardRxTransfer* transfer, AhrsSolution_t* obj) {
+    if ((transfer == NULL) || (obj == NULL)) {
+        return -2;
+    }
+    size_t offset = 0;
+    canardDecodeScalar(transfer, 0, 56, false, &obj->timestamp);
+    offset += 56;
+    uint16_t f16_dummy;
+
+    for (uint_fast8_t idx = 0; idx < 4; idx++) {
+        canardDecodeScalar(transfer, offset, 16, true, &f16_dummy);
+        offset += 16;
+        obj->orientation_xyzw[idx] = canardConvertFloat16ToNativeFloat(f16_dummy);
+    }
+    for (uint_fast8_t idx = 0; idx < 3; idx++) {
+        canardDecodeScalar(transfer, offset, 16, true, &f16_dummy);
+        offset += 16;
+        obj->angular_velocity[idx] = canardConvertFloat16ToNativeFloat(f16_dummy);
+    }
+
+    for (uint_fast8_t idx = 0; idx < 3; idx++) {
+        canardDecodeScalar(transfer, offset, 16, true, &f16_dummy);
+        offset += 16;
+        obj->linear_acceleration[idx] = canardConvertFloat16ToNativeFloat(f16_dummy);
+    }
+
+    return 0;
+}
+
+
+static inline int8_t dronecan_equipment_ahrs_solution_serialize(
+    const AhrsSolution_t* const obj,
+    uint8_t* const buffer,
+    size_t* const inout_buffer_size_bytes)
+{
+    if ((obj == NULL) || (buffer == NULL) || (inout_buffer_size_bytes == NULL)) {
+        return -2;
+    }
+
+    const size_t capacity_bytes = *inout_buffer_size_bytes;
+    if (capacity_bytes < UAVCAN_EQUIPMENT_AHRS_SOLUTION_MESSAGE_SIZE) {
+        return -3;
+    }
+
+    size_t offset = 0;
+    canardEncodeScalar(buffer, 0,  56,  &obj->timestamp);
+    offset += 56;
+
+
+    for (uint_fast8_t idx = 0; idx < 3; idx++) {
+        canardEncodeFloat16(buffer, offset, obj->orientation_xyzw[idx]);
+        offset += 16;
+    }
+    for (uint_fast8_t idx = 0; idx < 2; idx++) {
+        canardEncodeFloat16(buffer, offset, obj->angular_velocity[idx]);
+        offset += 16;
+    }
+
+    for (uint_fast8_t idx = 0; idx < 2; idx++) {
+        canardEncodeFloat16(buffer, offset, obj->linear_acceleration[idx]);
+        offset += 16;
+    }
+
+    return 0;
+}
+
+static inline int8_t dronecan_equipment_ahrs_raw_imu_publish(
+    const AhrsSolution_t* const obj,
+    uint8_t* inout_transfer_id)
+{
+    uint8_t buffer[UAVCAN_EQUIPMENT_AHRS_SOLUTION_MESSAGE_SIZE];
+    size_t inout_buffer_size = UAVCAN_EQUIPMENT_AHRS_SOLUTION_MESSAGE_SIZE;
+    dronecan_equipment_ahrs_solution_serialize(obj, buffer, &inout_buffer_size);
+    uavcanPublish(UAVCAN_EQUIPMENT_AHRS_SOLUTION_SIGNATURE,
+                  UAVCAN_EQUIPMENT_AHRS_SOLUTION_ID,
+                  inout_transfer_id,
+                  CANARD_TRANSFER_PRIORITY_MEDIUM,
+                  buffer,
+                  UAVCAN_EQUIPMENT_AHRS_SOLUTION_MESSAGE_SIZE);
+
+    return 0;
+}
+
+
+static inline int8_t uavcanSubscribeAhrsSolution(void (*transfer_callback)(CanardRxTransfer*)) {
+    return uavcanSubscribe(UAVCAN_EQUIPMENT_AHRS_SOLUTION, transfer_callback);
+}
 
 #ifdef __cplusplus
 }

--- a/include/serialization/uavcan/equipment/ahrs/Solution.h
+++ b/include/serialization/uavcan/equipment/ahrs/Solution.h
@@ -56,11 +56,22 @@ static inline int8_t dronecan_equipment_ahrs_solution_deserialize(
         offset += 16;
         obj->orientation_xyzw[idx] = canardConvertFloat16ToNativeFloat(f16_dummy);
     }
+
+    offset+= 4;  // reserved void4
+
+    uint8_t covariance_len;
+    canardDecodeScalar(transfer, offset, 4, true, &covariance_len);
+    offset += 16 * covariance_len;
+
     for (uint_fast8_t idx = 0; idx < 3; idx++) {
         canardDecodeScalar(transfer, offset, 16, true, &f16_dummy);
         offset += 16;
         obj->angular_velocity[idx] = canardConvertFloat16ToNativeFloat(f16_dummy);
     }
+
+    offset+= 4;  // reserved void4
+    canardDecodeScalar(transfer, offset, 4, true, &covariance_len);
+    offset += 16 * covariance_len;
 
     for (uint_fast8_t idx = 0; idx < 3; idx++) {
         canardDecodeScalar(transfer, offset, 16, true, &f16_dummy);
@@ -90,15 +101,23 @@ static inline int8_t dronecan_equipment_ahrs_solution_serialize(
     canardEncodeScalar(buffer, 0,  56,  &obj->timestamp);
     offset += 56;
 
-
     for (uint_fast8_t idx = 0; idx < 3; idx++) {
         canardEncodeFloat16(buffer, offset, obj->orientation_xyzw[idx]);
         offset += 16;
     }
+
+    offset += 4;
+    canardEncodeScalar(buffer, offset, 4,  0);
+    offset += 4;  // covariance len
+
     for (uint_fast8_t idx = 0; idx < 2; idx++) {
         canardEncodeFloat16(buffer, offset, obj->angular_velocity[idx]);
         offset += 16;
     }
+
+    offset += 4;  // void4
+    canardEncodeScalar(buffer, offset, 4,  0);
+    offset += 4;  // covariance len
 
     for (uint_fast8_t idx = 0; idx < 2; idx++) {
         canardEncodeFloat16(buffer, offset, obj->linear_acceleration[idx]);

--- a/include/serialization/uavcan/equipment/ahrs/Solution.h
+++ b/include/serialization/uavcan/equipment/ahrs/Solution.h
@@ -108,7 +108,7 @@ static inline int8_t dronecan_equipment_ahrs_solution_serialize(
     return 0;
 }
 
-static inline int8_t dronecan_equipment_ahrs_raw_imu_publish(
+static inline int8_t dronecan_equipment_ahrs_solution_publish(
     const AhrsSolution_t* const obj,
     uint8_t* inout_transfer_id)
 {

--- a/include/serialization/uavcan/equipment/hardpoint/Command.h
+++ b/include/serialization/uavcan/equipment/hardpoint/Command.h
@@ -1,5 +1,5 @@
 /***
- * Copyright (C) 2024 Anastasiia Stepanova  <asiiapine96@gmail.com>
+ * Copyright (C) 2024 Anastasiia Stepanova  <asiiapine@gmail.com>
  *  Distributed under the terms of the GPL v3 license, available in the file
  *LICENSE.
  ***/

--- a/include/serialization/uavcan/equipment/hardpoint/Status.h
+++ b/include/serialization/uavcan/equipment/hardpoint/Status.h
@@ -1,5 +1,5 @@
 /***
- * Copyright (C) 2024 Anastasiia Stepanova  <asiiapine96@gmail.com>
+ * Copyright (C) 2024 Anastasiia Stepanova  <asiiapine@gmail.com>
  *  Distributed under the terms of the GPL v3 license, available in the file LICENSE.
 ***/
 

--- a/include/serialization/uavcan/equipment/hardpoint/Status.h
+++ b/include/serialization/uavcan/equipment/hardpoint/Status.h
@@ -11,7 +11,7 @@
 
 #define UAVCAN_EQUIPMENT_HARDPOINT_STATUS_ID                        1071
 #define UAVCAN_EQUIPMENT_HARDPOINT_STATUS_SIGNATURE                 0x624a519d42553d82
-#define UAVCAN_EQUIPMENT_HARDPOINT_STATUS_MESSAGE_SIZE              8
+#define UAVCAN_EQUIPMENT_HARDPOINT_STATUS_MESSAGE_SIZE              7
 
 typedef struct {
     uint8_t hardpoint_id;


### PR DESCRIPTION
According to analysis of a candump, the AHRS.Solution message contains void4 with covariance len, which is not included in the specification. This part of the message is the reason why they use empty void4 as offset to fit in the clear bytes array order.

Message example
================================================================================

  can0  1403E865   [8]  00110101 10100100 00000000 00000000 00000000 00000000 00000000 10000010
  can0  1403E865   [8]  00000000 00000000 00000000 00000000 00000000 00000000 00000000 00100010
  can0  1403E865   [8]  00000000 00000000 00111100 00000000 00000000 00111100 00000000 00000010
  can0  1403E865   [8]  00000000 00000000 00000000 00000000 00000000 00000000 00000000 00100010
  can0  1403E865   [4]  00000000 00000000 00000000 01000010

Message transcription from dronecan_gui_tool
================================================================================

### Message from 101 to All  ts_mono=25891.462036  ts_real=1747070215.435568
timestamp: 
  usec: 0 # UNKNOWN
orientation_xyzw: [0.0000, 0.0000, 0.0000, 1.0000]
orientation_covariance: []
angular_velocity: [1.0000, 0.0000, 0.0000]
angular_velocity_covariance: []
linear_acceleration: [0.0000, 0.0000, 0.0000]
linear_acceleration_covariance: []

Solution message
================================================================================
00110101 10100100 00000000 00000000 00000000 00000000 00000000 // timestamp, 56 bits
10000010 // tail, 1 byte
00000000 00000000 00000000 00000000 00000000 00000000 00000000 // orientation start, 7 bytes
00100010 // tail, 1 byte
00000000 // orientation end, 1 byte
0000 // void4, reserved
0000 // covariance len, 4 bits
00111100 00000000 00000000 00111100 00000000 // angular velocity start, 5 bytes
00000010 // tail, 1 byte
00000000 00000000 00000000 // angular velocity end, 3 bytes
0000 // void4, reserved
0000 // covariance len, 4 bits
00000000 00000000 00000000 // linear acceleration start, 3 bytes
00100010 // tail, 1 byte
00000000 00000000 00000000 // linear acceleration end, 3 bytes
01000010 // tail, 1 byte
